### PR TITLE
Fixes for more reliable P25 decode at the start of calls

### DIFF
--- a/p25/P25RX.cpp
+++ b/p25/P25RX.cpp
@@ -86,6 +86,7 @@ void P25RX::reset()
     m_lostCount = 0U;
     m_countdown = 0U;
 
+    DEBUG1("P25RX::samples() m_state = P25RXS_NONE");
     m_state = P25RXS_NONE;
 
     m_duid = 0xFFU;
@@ -152,6 +153,7 @@ void P25RX::samples(const q15_t* samples, uint16_t* rssi, uint8_t length)
                 DEBUG4("P25RX::samples() dataPtr/startPtr/endPtr", m_dataPtr, m_startPtr, m_endPtr);
                 DEBUG4("P25RX::samples() lostCount/maxSyncPtr/minSyncPtr", m_lostCount, m_maxSyncPtr, m_minSyncPtr);
 
+                DEBUG1("P25RX::samples() m_state = P25RXS_SYNC");
                 m_state = P25RXS_SYNC;
                 m_countdown = 0U;
             }
@@ -226,7 +228,7 @@ void P25RX::processSample(q15_t sample)
 
                     frame[0U] = 0x01U; // has sync
                     serial.writeP25Data(frame, P25_HDU_FRAME_LENGTH_BYTES + 1U);
-                    reset();
+                    //reset();
                 }
                 return;
             case P25_DUID_TDU:
@@ -245,6 +247,7 @@ void P25RX::processSample(q15_t sample)
                 return;
             case P25_DUID_LDU1:
             case P25_DUID_VSELP1:
+                DEBUG1("P25RX::samples() m_state = P25RXS_VOICE");
                 m_state = P25RXS_VOICE;
                 break;
             case P25_DUID_TSDU:
@@ -263,9 +266,11 @@ void P25RX::processSample(q15_t sample)
                 return;
             case P25_DUID_LDU2:
             case P25_DUID_VSELP2:
+                DEBUG1("P25RX::samples() m_state = P25RXS_VOICE");
                 m_state = P25RXS_VOICE;
                 break;
             case P25_DUID_PDU:
+                DEBUG1("P25RX::samples() m_state = P25RXS_DATA");
                 m_state = P25RXS_DATA;
                 break;
             case P25_DUID_TDULC:

--- a/p25/P25RX.cpp
+++ b/p25/P25RX.cpp
@@ -198,20 +198,13 @@ void P25RX::setCorrCount(uint8_t count)
 
 void P25RX::processSample(q15_t sample)
 {
-    if (m_minSyncPtr < m_maxSyncPtr) {
-        if (m_dataPtr >= m_minSyncPtr && m_dataPtr <= m_maxSyncPtr)
-            correlateSync();
-    }
-    else {
-        if (m_dataPtr >= m_minSyncPtr || m_dataPtr <= m_maxSyncPtr)
-            correlateSync();
-    }
-
     // initial sample processing does not have an end pointer -- we simply wait till we've read
     // the samples up to the maximum sync pointer
     if (m_dataPtr == m_maxSyncPtr) {
         DEBUG4("P25RX::processSample() dataPtr/startPtr/endPtr", m_dataPtr, m_startPtr, m_maxSyncPtr);
         DEBUG4("P25RX::processSample() lostCount/maxSyncPtr/minSyncPtr", m_lostCount, m_maxSyncPtr, m_minSyncPtr);
+
+        calculateLevels(m_startPtr, P25_NID_LENGTH_SYMBOLS);
 
         if (!decodeNid(m_startPtr)) {
             io.setDecode(false);

--- a/p25/P25RX.cpp
+++ b/p25/P25RX.cpp
@@ -204,7 +204,7 @@ void P25RX::processSample(q15_t sample)
         DEBUG4("P25RX::processSample() dataPtr/startPtr/endPtr", m_dataPtr, m_startPtr, m_maxSyncPtr);
         DEBUG4("P25RX::processSample() lostCount/maxSyncPtr/minSyncPtr", m_lostCount, m_maxSyncPtr, m_minSyncPtr);
 
-        calculateLevels(m_startPtr, P25_NID_LENGTH_SYMBOLS);
+        // calculateLevels(m_startPtr, P25_NID_LENGTH_SYMBOLS);
 
         if (!decodeNid(m_startPtr)) {
             io.setDecode(false);

--- a/p25/P25RX.cpp
+++ b/p25/P25RX.cpp
@@ -591,6 +591,8 @@ bool P25RX::decodeNid(uint16_t start)
     uint8_t nid[P25_NID_LENGTH_BYTES];
     samplesToBits(nidStartPtr, P25_NID_LENGTH_SYMBOLS, nid, 0U, m_centreVal, m_thresholdVal);
 
+    DEBUG3("P25RX::decodeNid() sync [b0 - b1]", nid[0], nid[1]);
+
     if (m_nac == 0xF7EU) {
         m_duid = nid[1U] & 0x0FU;
         DEBUG2("P25RX::decodeNid() DUID for xDU", m_duid);

--- a/p25/P25RX.cpp
+++ b/p25/P25RX.cpp
@@ -158,9 +158,16 @@ void P25RX::samples(const q15_t* samples, uint16_t* rssi, uint8_t length)
         }
 
         m_dataPtr++;
-        if (m_dataPtr >= P25_PDU_FRAME_LENGTH_SAMPLES) {
-            m_duid = 0xFFU;
-            m_dataPtr = 0U;
+        if (m_state != P25RXS_DATA) {
+            if (m_dataPtr >= P25_LDU_FRAME_LENGTH_SAMPLES) {
+                m_duid = 0xFFU;
+                m_dataPtr = 0U;
+            }
+        } else {
+            if (m_dataPtr >= P25_PDU_FRAME_LENGTH_SAMPLES) {
+                m_duid = 0xFFU;
+                m_dataPtr = 0U;
+            }
         }
 
         m_bitPtr++;
@@ -219,19 +226,9 @@ void P25RX::processSample(q15_t sample)
 
                     frame[0U] = 0x01U; // has sync
                     serial.writeP25Data(frame, P25_HDU_FRAME_LENGTH_BYTES + 1U);
-
-                    if (m_minSyncPtr < m_maxSyncPtr) {
-                        if (m_dataPtr >= m_minSyncPtr && m_dataPtr <= m_maxSyncPtr)
-                            correlateSync();
-                    }
-                    else {
-                        if (m_dataPtr >= m_minSyncPtr || m_dataPtr <= m_maxSyncPtr)
-                            correlateSync();
-                    }
-
-                    m_state = P25RXS_VOICE;
+                    reset();
                 }
-                break;
+                return;
             case P25_DUID_TDU:
                 {
                     calculateLevels(m_startPtr, P25_TDU_FRAME_LENGTH_SYMBOLS);


### PR DESCRIPTION
- Removed unnecessary state machine `reset()` after HDU is decoded
- Removed unnecessary sync correlation calls 
- Added debug prints for p25 RX state machine